### PR TITLE
✨ feat(jenkins-trigger): Add workflow to trigger Jenkins job for AR Generator Service

### DIFF
--- a/.github/workflows/jenkins-trigger-ar-generator.yml
+++ b/.github/workflows/jenkins-trigger-ar-generator.yml
@@ -1,0 +1,31 @@
+name: Trigger Jenkins Job AR Generator Service
+
+on:
+  push:
+    branches:
+      - "dev-ar-generator-service-test"
+  pull_request:
+    branches:
+      - "dev-ar-generator-service-test"
+  workflow_dispatch:
+
+jobs:
+  trigger-job:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Build Jenkins URL
+      - name: Build Jenkins URL
+        run: |
+          JENKINS_URL="https://automation.prms.cgiar.org/job/ar-generator-pro/build"
+          echo "Jenkins job URL: $JENKINS_URL"
+          echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
+
+      # Step 2: Trigger Jenkins Job
+      - name: Trigger Jenkins Job
+        run: |
+          curl -X POST ${{ env.JENKINS_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+        env:
+          JENKINS_URL: ${{ env.JENKINS_URL }}
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to trigger a Jenkins job for the AR Generator Service. The workflow is designed to automate job execution upon specific events and provides secure handling of credentials.

### New GitHub Actions Workflow:

* [`.github/workflows/jenkins-trigger-ar-generator.yml`](diffhunk://#diff-455e6e061e5e3b30cbeba0ae212766079557cae3ed9599a4a7467978b46f10bcR1-R31): Added a workflow named "Trigger Jenkins Job AR Generator Service" that triggers a Jenkins job on `push`, `pull_request`, and `workflow_dispatch` events for the `dev-ar-generator-service-test` branch. It includes steps to build the Jenkins URL dynamically and securely trigger the job using stored secrets for authentication.