### PR TITLE
chore(workflow): Update Jenkins trigger workflow for improved clarity

### DIFF
--- a/.github/workflows/jenkins-trigger-ai-text-mining.yml
+++ b/.github/workflows/jenkins-trigger-ai-text-mining.yml
@@ -3,10 +3,10 @@ name: Trigger Jenkins Job AI Text Mining Microservice
 on:
   push:
     branches:
-      - "main" # Only on push to main-mining
+      - "main-text-mining" # Only on push to main-mining
   pull_request:
     branches:
-      - "main" # Only on PR to main-mining
+      - "main-text-mining" # Only on PR to main-mining
   workflow_dispatch: # Allows manual trigger if needed
 
 jobs:


### PR DESCRIPTION
This pull request updates the workflow trigger configuration for the Jenkins AI Text Mining Microservice. The workflow will now run only on pushes and pull requests to the `main-text-mining` branch instead of the previous `main` branch.

* Changed workflow triggers in `.github/workflows/jenkins-trigger-ai-text-mining.yml` to target the `main-text-mining` branch for both push and pull request events.