### PR TITLE
Main text mining

### DIFF
--- a/.github/workflows/jenkins-trigger-ai-text-mining.yml
+++ b/.github/workflows/jenkins-trigger-ai-text-mining.yml
@@ -3,10 +3,10 @@ name: Trigger Jenkins Job AI Text Mining Microservice
 on:
   push:
     branches:
-      - "main" # Only on push to main-mining
+      - "main-text-mining" # Only on push to main-mining
   pull_request:
     branches:
-      - "main" # Only on PR to main-mining
+      - "main-text-mining" # Only on PR to main-mining
   workflow_dispatch: # Allows manual trigger if needed
 
 jobs:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to trigger on the correct branch for the AI Text Mining Microservice. The workflow now listens to events on the `main-text-mining` branch instead of the previously configured `main` branch.

* Changed the workflow trigger in `.github/workflows/jenkins-trigger-ai-text-mining.yml` to use the `main-text-mining` branch for both push and pull request events, ensuring the Jenkins job is only triggered for changes relevant to the text mining microservice.