### PR TITLE
chore(workflow): Update Jenkins trigger workflow for improved clarity

### DIFF
--- a/.github/workflows/jenkins-trigger-ar-generator.yml
+++ b/.github/workflows/jenkins-trigger-ar-generator.yml
@@ -3,10 +3,10 @@ name: Trigger Jenkins Job AR Generator Service
 on:
   push:
     branches:
-      - "dev-ar-generator-service-test"
+      - "main-ar-generator"
   pull_request:
     branches:
-      - "dev-ar-generator-service-test"
+      - "main-ar-generator"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request updates the branch triggers for the Jenkins job workflow in `.github/workflows/jenkins-trigger-ar-generator.yml` to align with the new branch naming convention.

Workflow trigger update:

* Changed the workflow triggers from the old `dev-ar-generator-service-test` branch to the new `main-ar-generator` branch for both `push` and `pull_request` events.