### PR TITLE
chore(jenkins-trigger): Update workflow file for consistency and clarity

### DIFF
--- a/.github/workflows/jenkins-trigger-fast-response.yml
+++ b/.github/workflows/jenkins-trigger-fast-response.yml
@@ -3,10 +3,10 @@ name: Trigger Jenkins Job fast Response Service
 on:
   push:
     branches:
-      - "dev-fast-response"
+      - "main-fast-response"
   pull_request:
     branches:
-      - "dev-fast-response"
+      - "main-fast-response"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request updates the workflow configuration for triggering the Jenkins job for the fast response service. The workflow will now run on pushes and pull requests to the `main-fast-response` branch instead of the previous `dev-fast-response` branch.

Workflow configuration update:

* Changed the target branch for triggering the workflow from `dev-fast-response` to `main-fast-response` in `.github/workflows/jenkins-trigger-fast-response.yml` for both `push` and `pull_request` events.